### PR TITLE
remove-number-litters

### DIFF
--- a/make_24/graph/node.py
+++ b/make_24/graph/node.py
@@ -34,7 +34,10 @@ class Node:
     def printAllHistory(self):
         for parent in self.getParents():
             parent.printAllHistory()
-        print(self)
+
+        # only print the operation nodes
+        if isinstance(self, OpNode):
+            print(self)
 
 
 class NumberNode(Node):

--- a/test/test_node.py
+++ b/test/test_node.py
@@ -49,6 +49,9 @@ def test_print_all_history(capfd):
     assert "18 - 6 -> 12" in out
     assert "12 / 3 -> 4" in out
 
+    # ensure 6 and 18 are not printed
+    assert "6" not in out.replace("18 / 6", "").replace("18 - 6", "")
+    assert "18" not in out.replace("18 / 6", "").replace("18 - 6", "")
 
 #
 # simple_spawn_from_pair


### PR DESCRIPTION
used isinstance() inside printAllHistory method. now, it'll skip the single numbers

Closes #4 